### PR TITLE
Fix snipMate Deprecated

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -75,6 +75,7 @@ filetype plugin indent on    " required
 " }
 
 " PLUGINS {
+  let g:snipMate = { 'snippet_version' : 1 }
   " ctrlP {
      let g:ctrlp_map = '<c-p>'
      let g:ctrlp_cmd = 'CtrlP'


### PR DESCRIPTION
Issues: The legacy SnipMate parser is deprecated. Please see :h SnipMate-deprecate.
Press ENTER or type command to continue